### PR TITLE
[bugfix-php7.1] Default style to empty array instead of string

### DIFF
--- a/classes/textile.php
+++ b/classes/textile.php
@@ -1693,7 +1693,7 @@ class Textile
      */
     protected function parseAttribsToArray($in, $element = '', $include_id = true, $autoclass = '')
     {
-        $style = '';
+        $style = [];
         $class = '';
         $lang = '';
         $colspan = '';


### PR DESCRIPTION
Withersworldwide professional service
1/00040312.007